### PR TITLE
X-Rayアダプタを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The Nablarch Framework consists of features organized into about 83 modules. The
 | [nablarch-mail-sender-velocity-adaptor](https://github.com/nablarch/nablarch-mail-sender-velocity-adaptor)     | Adaptor for Velocity (E-mail Template)      |
 | [nablarch-web-thymeleaf-adaptor](https://github.com/nablarch/nablarch-web-thymeleaf-adaptor)                   | Adaptor for Thymeleaf (for Web Application) |
 | [nablarch-redisstore-lettuce-adaptor](https://github.com/nablarch/nablarch-redisstore-lettuce-adaptor)         | Adaptor for Lettuce (for Redis session store) |
+| [nablarch-aws-xray-adaptor](https://github.com/nablarch/nablarch-aws-xray-adaptor)                             | Adaptor for AWS X-Ray                       |
 | [nablarch-micrometer-adaptor](https://github.com/nablarch/nablarch-micrometer-adaptor)                         | Adaptor for Micrometer                      |
 | [slf4j-nablarch-adaptor](https://github.com/nablarch/slf4j-nablarch-adaptor)                                   | Adapter to use Nablarch Logger via SLF4J    |
 


### PR DESCRIPTION
This reverts commit 2e5b76205af88a40519c1604278e2fbfde32e188.

AWS X-RayアダプタはAWSから[Javaエージェントとして動作するAWS X-Rayクライアント](https://aws.amazon.com/jp/about-aws/whats-new/2020/09/aws-x-ray-launches-auto-instrumentation-agent-for-java/)がリリースされたためにNablarch5u18でのリリースを見送っていた。
しかし、Javaエージェントの動作を検証したところ、Nablarchでは利用できなかったため、5u19にてリリースすることになった。
