### PR TITLE
Revert "X-Rayアダプタを削除"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ The Nablarch Framework consists of features organized into about 83 modules. The
 | [nablarch-mail-sender-velocity-adaptor](https://github.com/nablarch/nablarch-mail-sender-velocity-adaptor)     | Adaptor for Velocity (E-mail Template)      |
 | [nablarch-web-thymeleaf-adaptor](https://github.com/nablarch/nablarch-web-thymeleaf-adaptor)                   | Adaptor for Thymeleaf (for Web Application) |
 | [nablarch-redisstore-lettuce-adaptor](https://github.com/nablarch/nablarch-redisstore-lettuce-adaptor)         | Adaptor for Lettuce (for Redis session store) |
-| [nablarch-aws-xray-adaptor](https://github.com/nablarch/nablarch-aws-xray-adaptor)                             | Adaptor for AWS X-Ray                       |
 | [nablarch-micrometer-adaptor](https://github.com/nablarch/nablarch-micrometer-adaptor)                         | Adaptor for Micrometer                      |
 | [slf4j-nablarch-adaptor](https://github.com/nablarch/slf4j-nablarch-adaptor)                                   | Adapter to use Nablarch Logger via SLF4J    |
 


### PR DESCRIPTION
5u19でX-Rayアダプタをリリースしようとしたが、AWS Distro for OpenTelemetryを使用すればJavaエージェントで分散トレーシングを実現できる可能性があることがわかった。
アダプタをリリースしたあとにJavaエージェントに方針転換すると利用者を混乱させるため、5u19ではアダプタではなくSDKを使用した分散トレーシングの方法をガイドし、アダプタのリリースは見送ることとした。This reverts commit 2e5b76205af88a40519c1604278e2fbfde32e188.